### PR TITLE
PrivateLayout + Sidenavbar

### DIFF
--- a/src/components/DashboardComponents/Topbar.tsx
+++ b/src/components/DashboardComponents/Topbar.tsx
@@ -1,14 +1,20 @@
-import { Flex, Text, InputGroup, Input, Box, IconButton } from "@chakra-ui/react";
-import { FaSearch, FaBell } from "react-icons/fa";
-import { useColorModeValue } from "@/components/ui/color-mode";
+import { Flex, Text, InputGroup, Input, Box, IconButton, Button, useBreakpointValue } from '@chakra-ui/react';
+import { FaSearch, FaBell } from 'react-icons/fa';
+import { useColorModeValue } from '@/components/ui/color-mode';
+import { MdMenu } from 'react-icons/md';
+import useSidenavbarStore from '@/store/useSidenavbarStore';
 
 const Topbar = () => {
+  const { setIsOpen, titleToTopBar } = useSidenavbarStore();
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
   const bg = useColorModeValue("white", "sidenavbar.dark");
   const color = useColorModeValue("black", "white");
+
   return (
     <Flex
       as="header"
-      w="100%"
+      w="full"
       py={4}
       px={6}
       align="center"
@@ -17,8 +23,18 @@ const Topbar = () => {
       boxShadow="soft"
       height="24"
     >
+      {isMobile &&
+        <Button
+          h={"auto"}
+          p={"10px"}
+          mr={"4px"}
+          variant={"ghost"}
+          onClick={() => setIsOpen()}>
+          <MdMenu />
+        </Button>
+      }
       <Text fontSize="lg" fontWeight="bold" color={color}>
-        ¡Bienvenido Carlos!
+        { titleToTopBar ?? "Nombre tienda" }
       </Text>
 
       <Flex align="center" gap={4}>

--- a/src/components/Sidenavbar/Sidenavbar.tsx
+++ b/src/components/Sidenavbar/Sidenavbar.tsx
@@ -1,16 +1,26 @@
-import { Flex } from "@chakra-ui/react";
-import MobileTopBar from "./SidenavbarComponents/MobileTopBar";
-import MainSidenavbarMenu from "./SidenavbarComponents/MainSidenavbarMenu";
+import { VStack, useBreakpointValue } from '@chakra-ui/react';
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import MainSidenavbarMenu from './SidenavbarComponents/MainSidenavbarMenu';
 
 const Sidenavbar = () => {
+	const { isOpen } = useSidenavbarStore();
+    const isMobile = useBreakpointValue({ base: true, md: false });
+
 	return (
-		<Flex
-			direction={"column"}
-			position={{ md: "sticky" }}
-			top={{ md: "30px" }}>
-			<MobileTopBar />
+		<VStack
+			as={"aside"}
+			position={"sticky"}
+			w={"fit-content"}
+			h={"100vh"}
+			p={4}
+			justifyContent={"space-between"}
+			bg={{ base: "sidenavbar.light", _dark: "sidenavbar.dark" }}
+			shadow={{ base: "2px 0px 4px rgba(0, 0, 0, 0.1)", _dark: "2px 0px 4px rgba(255, 255, 255, 0.1)" }}
+			transform={isMobile && !isOpen ? "translateX(-100%)" : "translateX(0)"}
+			transition={isMobile ? "transform 0.3s ease-in-out" : ""}
+			zIndex={100}>
 			<MainSidenavbarMenu />
-		</Flex >
+		</VStack>
 	)
 }
 export default Sidenavbar;

--- a/src/components/Sidenavbar/SidenavbarComponents/CollapseMenuButton.tsx
+++ b/src/components/Sidenavbar/SidenavbarComponents/CollapseMenuButton.tsx
@@ -1,0 +1,29 @@
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { Button, Text, useBreakpointValue } from '@chakra-ui/react';
+import { TbLayoutSidebarLeftCollapseFilled, TbLayoutSidebarLeftExpandFilled } from 'react-icons/tb';
+
+const CollapseMenuButton = () => {
+	const { isToggle, setIsOpen, setToggle } = useSidenavbarStore();
+    const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
+
+	return (
+		<Button
+			w={"full"}
+			p={"14px"}
+			h={"auto"}
+			colorPalette={"green"}
+			onClick={() => isMobile ? setIsOpen() : setToggle(!isToggle)}>
+			{isToggle
+				? <TbLayoutSidebarLeftExpandFilled />
+				: <TbLayoutSidebarLeftCollapseFilled />
+			}
+
+			<Text
+				display={{ base: "block", md: isToggle ? "none" : "" }}>
+				Minimizar
+			</Text>
+		</Button>
+	)
+}
+
+export default CollapseMenuButton;

--- a/src/components/Sidenavbar/SidenavbarComponents/MainSidenavbarMenu.tsx
+++ b/src/components/Sidenavbar/SidenavbarComponents/MainSidenavbarMenu.tsx
@@ -1,83 +1,41 @@
-import { Box, Button, Flex, HStack, IconButton, Image, Separator, SystemStyleObject, Text, useBreakpointValue, VStack } from '@chakra-ui/react';
-import { MdBarChart, MdHistory, MdHomeFilled, MdInventory, MdOutlinePersonPin, MdOutlineVerifiedUser, MdPointOfSale } from 'react-icons/md';
-import Logo from '@/assets/logo.svg';
-import useSidenavbarStore from '@/store/useSidenavbarStore';
-import useAutocloseSidenavbar from '@/hooks/useAutocloseSidenavbar';
+import { Box, Flex, HStack, IconButton, Image, Text, useBreakpointValue, VStack } from '@chakra-ui/react';
+import { MdBarChart, MdHomeFilled, MdInventory, MdMenu, MdPerson, MdPointOfSale } from 'react-icons/md';
 import NavItem from './NavItem';
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import Logo from '@/assets/logo.svg';
 
 const MainSidenavbarMenu = () => {
 
-    const { isOpen, setIsOpen } = useSidenavbarStore()
-    const isMobile = useBreakpointValue({ base: true, md: false })
-    useAutocloseSidenavbar(isMobile ? isMobile : false);
-
-    const sidenavabarStyles: SystemStyleObject = {
-        "& a, & button": {
-            w: "full",
-            px: "16px", py: "14px",
-            display: "flex",
-            alignItems: "center",
-            gap: 3,
-            fontWeight: "bold",
-            fontSize: "14px",
-            borderRadius: "16px"
-        },
-        "& a.active": { bg: "yellow.amarillo" },
-        "& a:hover": { bg: "yellow.400" },
-    }
+    const { setIsOpen, setToggle, isToggle } = useSidenavbarStore();
+    const isMobile = useBreakpointValue({ base: true, md: false });
 
     return (
-        <Box
-            h={{ base: "100vh", md: "auto" }}
-            p={{ base: "20px", md: "0" }}
-            bg={{ base: "sidenavbar.light", _dark: "sidenavbar.dark" }}
-            position={{ base: "absolute", md: "relative" }}
-            transform={isMobile && !isOpen ? 'translateX(-100%)' : 'translateX(0)'}
-            transition={"transform 0.3s ease-in-out"}
-            shadow={{ base: "lg", md: "none" }}
-            top={0} left={0}
-            css={sidenavabarStyles}>
-            <HStack gap={4}>
-                <Image
-                    src={Logo} alt="Logo Beetrack" maxWidth={"50px"} />
-                <Box>
-                    <Text as={"p"} fontWeight={"bold"}>BEETRACK</Text>
-                    <Text as={"p"} fontSize={"2xs"}>SALES & MINORY MANAGER</Text>
-                </Box>
-                {/* <IconButton variant={"ghost"} onClick={() => setIsOpen(false)} display={{ base: "inline-flex", md: "none" }} position={{ base: "absolute", xs: "relative" }} bottom={{ base: "30px", xs: "auto" }} left={{ base: "20px", xs: "auto" }}>
-                    <MdClose />
-                </IconButton> */}
-            </HStack>
-            <Separator my={"10px"} />
-            <Flex direction={"column"} justifyContent={"space-between"} h={"100vh"}>
-                <VStack gap={"24px"} alignItems={"start"} w={"full"}>
-                    <NavItem to="/">
-                        <MdHomeFilled />
-                        Inicio
-                    </NavItem>
-                    <NavItem to={"/inventario"}>
-                        <MdInventory />
-                        Inventario
-                    </NavItem>
-                    <NavItem to={"/ventas"}>
-                        <MdPointOfSale />
-                        Ventas
-                    </NavItem>
-                    <NavItem to={"/estadisticas"}>
-                        <MdBarChart />
-                        Estadísticas
-                    </NavItem>
-                    <Button variant={"solid"} colorPalette={"red"} textAlign={"left"} onClick={() => setIsOpen(false)} display={{ base: "inline-flex", md: "none!" }}>
-                        {/* <MdClose /> */}
-                        Cerrar menú
-                    </Button>
-                </VStack>
-                <NavItem to={"/perfil"}>
-                    <MdOutlinePersonPin />
-                    Perfil
-                </NavItem>
+        <VStack id="main-menu-item" h={"full"} gap={"24px"} zIndex={10}>
+            <Flex gap={4} alignItems={"center"}>
+                <IconButton
+                    variant={"ghost"}
+                    onClick={() => isMobile ? setIsOpen(false) : setToggle()}>
+                    <MdMenu />
+                </IconButton>
+                <HStack display={{ base: "flex", md: isToggle ? "none" : "" }}>
+                    <Image
+                        src={Logo} alt="Logo Beetrack" maxWidth={"50px"} />
+                    <Box>
+                        <Text as={"p"} fontWeight={"bold"}>BEETRACK</Text>
+                        <Text as={"p"} fontSize={"2xs"}>SALES & MINORY MANAGER</Text>
+                    </Box>
+                </HStack>
             </Flex>
-        </Box>
+            <VStack w={"full"} h={"full"}>
+                <NavItem to="/" icon={<MdHomeFilled />} text="Home" />
+                <NavItem to="/inventario" icon={<MdInventory />} text="Inventario" />
+                <NavItem to="/ventas" icon={<MdPointOfSale />} text="Ventas" />
+                <NavItem to="/estadisticas" icon={<MdBarChart />} text="Estadísticas" />
+                <Box asChild marginTop={"auto"}>
+                    <NavItem to="/perfil" icon={<MdPerson />} text="Perfil" />
+                </Box>
+            </VStack>
+        </VStack>
     )
 }
 

--- a/src/components/Sidenavbar/SidenavbarComponents/NavItem.tsx
+++ b/src/components/Sidenavbar/SidenavbarComponents/NavItem.tsx
@@ -1,24 +1,50 @@
-import useSidenavbarStore from "@/store/useSidenavbarStore";
-import { ReactNode } from "react";
-import { IconType } from "react-icons/lib";
-import { NavLink } from "react-router-dom";
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { Button, Text } from '@chakra-ui/react';
+import { SystemStyleObject } from '@chakra-ui/system';
+import { ReactElement } from 'react';
+import { NavLink } from 'react-router-dom';
 
 type NavItemProps = {
     to: string;
-    children: ReactNode;
-    icon?: IconType;
+    text: string; // Texto del botón
+    icon?: ReactElement;
 }
 
-const NavItem = ({ to, children, icon }: NavItemProps) => {
-    
+const NavItem = ({ to, text, icon, ...rest }: NavItemProps) => {
+
+    const { isToggle } = useSidenavbarStore();
     const { setIsOpen } = useSidenavbarStore();
-    
+
+    const sidenavabarStyles: SystemStyleObject = {
+        "&.active": { bg: "yellow.amarillo" },
+    }
+
     return (
-        <NavLink
-            to={to}
-            onClick={() => setIsOpen(false)} className={({ isActive }) => isActive ? "active" : "pending"}>
-                { children }
-        </NavLink>
+        <Button
+            asChild
+            w={"full"}
+            p={"14px"}
+            h={"auto"}
+            gap={3}
+            fontWeight={"bold"}
+            fontSize={"14px"}
+            justifyContent={"start"}
+            borderRadius={"16px"}
+            _hover={{ bg: "yellow.400" }}
+            variant={"ghost"}
+            css={sidenavabarStyles}
+            {...rest}>
+            <NavLink
+                to={to}
+                className={({ isActive }) => isActive ? "active" : "pending"}
+                onClick={() => setIsOpen(false)}>
+                {icon}
+                <Text
+                    display={{ base: "block", md: isToggle ? "none" : "" }}>
+                    {text}
+                </Text>
+            </NavLink>
+        </Button>
     )
 }
 

--- a/src/components/ui/OverlayToLayout.tsx
+++ b/src/components/ui/OverlayToLayout.tsx
@@ -1,0 +1,22 @@
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { Box } from '@chakra-ui/react';
+
+const OverlayToLayout = () => {
+	const { isOpen, setIsOpen } = useSidenavbarStore();
+
+	return (
+		<Box id="overlay"
+			display={isOpen ? "block" : "none"}
+			position={"absolute"}
+			top={0}
+			right={0}
+			bottom={0}
+			left={0}
+			bg={"rgba(0, 0, 0, 0.5)"}
+			backdropFilter={"blur(10px)"}
+			zIndex={"1"}
+			onClick={() => { setIsOpen(false) }} />
+	)
+}
+
+export default OverlayToLayout;

--- a/src/docs/agenda-sprints.md
+++ b/src/docs/agenda-sprints.md
@@ -1,0 +1,49 @@
+# AGENDA POR SPRINTS
+
+## SPRINT 1 👟
+
+- [x] Configurar enrutamiento con React Router DOM. `(Jonathan/Jason)`
+- [x] Configurar manejo del estado global. `(Andrés/Jason)`
+- [x] Configurar entorno. `(Javi)`
+- [x] Implementar un layout base. `(German)`
+- [x] Crear un tema global con Chakra UI y TypeScript. `(Javi)`
+
+## SPRINT 2 👟
+
+- Según el Kanban:
+  - [ ] Agregar funcionalidad de formulario al login. `(Jason)`
+  - [ ] Configurar navegación desde registro a login. `(Jason)`
+  - [ ] Implementar el componente de la pantalla de registro. `(Jason)`
+  - [ ] Implementar el componente de la pantalla de login. `(Jason)`
+  - [ ] Implementar el componente de la pantalla de dashboard. `(German)`
+  - [ ] Crear la barra lateral de navegación. `(Javi)`
+
+- Según flujos de trabajo internos:
+  - [ ] Dashboard. `(German)`
+  - [ ] Login/Register. `(Jason)`
+  - [ ] Inventario. `(Jonathan)`
+  - [ ] Ventas. `(Andrés)`
+  - [ ] Perfil. `(Javi)`
+  - [ ] Alertas.
+
+## SPRINT 3 👟
+
+- Según el Kanban:
+  - [ ] Agregar responsive design al dashboard.
+  - [ ] Implementar el componente de la pantalla perfil.
+  - [ ] Permitir edición del perfil.
+  - [ ] Implementar el componente de lista.
+  - [ ] Agregar paginación a la lista.
+  - [ ] Añadir funcionalidad de búsqueda.
+  - [ ] Implementar el componente detalle.
+  - [ ] Configurar navegación desde la lista a detalle.
+
+## SPRINT 4 👟
+
+- Según el Kanban:
+  - [ ] Crear un componente de botón reutilizable.
+  - [ ] Crear un componente de modal reutilizable.
+  - [ ] Crear un componente de card reutilizable.
+  - [ ] Agregar manejo de errores.
+  - [ ] Optimizar el rendimiento de la aplicación.
+  - [ ] Configurar meta tags y SEO.

--- a/src/docs/dudas-soluciones.md
+++ b/src/docs/dudas-soluciones.md
@@ -1,0 +1,31 @@
+# LISTADO DE SEGUIMIENTO DE DUDAS
+
+### Ejemplo de cómo estructurar una duda.
+EQUIPO A QUIÉN VA DIRIGIDA - Duda en cuestión.
+
+`BACK - Gestión de la entidades`
+
+## PLANTEADAS
+> Propuestas pero que todavíano han obtenido feedback.
+
+
+## EN CONSULTA
+> La/s persona/s implicada conoce la problemática y se está buscando solución.
+
+- [ ] BACK - Cómo gestionar el guardado/recuperación de la imagen por producto.
+- [ ] UX/UI - Botón de cerrar menú. `Se plantean dos escenarios: para desktop un botón de toggle parcial / para mobile toggle total.`
+- [ ] Login con Facebook o Google.
+
+
+## EN PROGRESO
+> Se está trabajando en la solución.
+
+- [ ] BACK - Cookie HTTP-only para el manejo de sesión.
+- [ ] UX/UI - Control de flujos de la aplicación. `Se siguen ajustando distintos elementos, y falta cerrar las vistas de perfil, alertas y estadísticas.`
+-  [ ] UX/UI - Botón flotante para agregar/editar producto. `Ha cambiado (07/04) siendo un botón fijo en la parte superior de la vista inventario.`
+-  [ ] UX/UI - Colores de los botones en sus diferentes estados (base, hover, active, active+hover). `Se explica en el Figma.`
+
+## RESUELTAS
+> Cerradas.
+
+-  [ ] UX/UI - Iconos de material design no coinciden. `Finalmente se encuentran casi todos, y se recurrirá a otros en caso de no coincidir. Existe un documento Icons.md en la carpeta /docs/ para guiarse.`

--- a/src/hooks/useAutocloseSidenavbar.ts
+++ b/src/hooks/useAutocloseSidenavbar.ts
@@ -1,12 +1,13 @@
-import useSidenavbarStore from "@/store/useSidenavbarStore";
-import { useEffect } from "react";
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { useBreakpointValue } from '@chakra-ui/react';
+import { useEffect } from 'react';
 
-const useAutocloseSidenavbar = (isMobile: boolean) => {
-    const { setIsOpen } = useSidenavbarStore();
-
+const useAutocloseSidenavbar = () => {
+    const { isOpen, setIsOpen } = useSidenavbarStore();
+    const isMobile = useBreakpointValue({ base: true, md: false });
+    
     useEffect(() => {
-        console.log("Cambio: ", isMobile)
-        if(!isMobile) setIsOpen(false);
+        if(!isMobile && isOpen) setIsOpen(false);
     }, [isMobile]);
 }
 

--- a/src/hooks/useToolbarTitle.ts
+++ b/src/hooks/useToolbarTitle.ts
@@ -1,0 +1,17 @@
+import ROUTES_METADATA from '@/routes/routesMetadata';
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { useEffect } from 'react';
+import { matchPath, useLocation } from 'react-router-dom'
+
+export const useToolbarTittle = () => {
+	const location = useLocation();
+	const  { setTitleToTopBar } = useSidenavbarStore();
+
+	useEffect(() => {
+		const pathname = location.pathname;
+		const matched = Object.entries(ROUTES_METADATA).find(([ path ]) => matchPath(path, pathname));
+
+		const title = matched?.[1].title ?? "No title";
+		setTitleToTopBar(title);
+	}, [location.pathname])
+}

--- a/src/layout/PrivateLayout.tsx
+++ b/src/layout/PrivateLayout.tsx
@@ -1,10 +1,12 @@
-import { ReactNode } from "react";
-import Topbar from "@/components/DashboardComponents/Topbar";
-import Sidenavbar from "@/components/Sidenavbar/Sidenavbar";
-import { Box, Grid, GridItem } from "@chakra-ui/react";
-import { Outlet } from "react-router-dom";
-import useSidenavbarStore from "@/store/useSidenavbarStore";
-// import { ColorModeButton } from "@/components/ui/color-mode";
+import { ReactNode } from 'react';
+import { Box, useBreakpointValue } from '@chakra-ui/react';
+import { ColorModeButton } from '@/components/ui/color-mode';
+import Sidenavbar from '@/components/Sidenavbar/Sidenavbar';
+import Topbar from '@/components/DashboardComponents/Topbar';
+import { Outlet } from 'react-router-dom';
+import useAutocloseSidenavbar from '@/hooks/useAutocloseSidenavbar';
+import OverlayToLayout from '@/components/ui/OverlayToLayout';
+import { useToolbarTittle } from '@/hooks/useToolbarTitle';
 
 type PrivateLayoutProps = {
   children?: ReactNode;
@@ -20,50 +22,28 @@ const PrivateLayout = ({
   contentPadding = "0"
 }: PrivateLayoutProps) => {
 
-  const { isOpen } = useSidenavbarStore();
+  const isMobile = useBreakpointValue({ base: true, md: false });
+  useAutocloseSidenavbar();
+  useToolbarTittle();
 
   return (
-    <>
-      {/* El botón del modo es para visualizar light/dark y es una demo */}
+    <Box
+      display={"flex"}
+      position={"relative"}>
       {/* <ColorModeButton pos={"fixed"} bottom={"10px"} left={"10px"} zIndex={1000} border={"md"} borderColor={{ base: "black", _dark: "white" }} /> */}
-
-      <Grid templateColumns={"repeat(6, 1fr)"} bg={"gray.50"} minH={"100vh"}>
-        {showSidebar && (
-          <GridItem
-            as={"aside"}
-            colSpan={{ base: 6, md: 1 }}
-            position={{ base: "fixed", md: "initial" }}
-            w={{ base: "100%" }}
-            h={{ base: "fit", md: "auto" }}
-            p={{ base: "20px", lg: "30px" }}
-            bg={{ base: "sidenavbar.light", _dark: "sidenavbar.dark" }}
-            shadow={{ base: "2px 0px 4px rgba(0, 0, 0, 0.1)", _dark: "2px 0px 4px rgba(255, 255, 255, 0.1)" }}
-            zIndex={100}>
-            <Sidenavbar />
-          </GridItem>
-        )}
-        <GridItem
-          as={"main"}
-          colSpan={{ base: 6, md: 5 }}
-          mt={{ base: "100px", md: 0 }} // De momento para que en el modo móvil el topbar siga viéndose
-          p={contentPadding}
-          bg={{ base: "content.light", _dark: "content.dark" }}
-        >
-          {showTopbar && <Topbar />}
-          {children || <Outlet />}
-        </GridItem>
-      </Grid>
-      <Box id="overlay"
-        display={isOpen ? "block" : "none"}
-        position={"absolute"}
-        top={0}
-        right={0}
-        bottom={0}
-        left={0}
-        bg={"rgba(0, 0, 0, 0.5)"}
-        backdropFilter={"blur(10px)"}
-        zIndex={"1"} />
-    </>
+      <Sidenavbar />
+      <Box
+        as={"main"}
+        position={isMobile ? "absolute" : "relative"} overflowY={"auto"}
+        w={"full"}
+        h={"100vh"}
+        p={contentPadding}
+        bg={{ base: "content.light", _dark: "content.dark" }}>
+        {showTopbar && <Topbar />}
+        {children || <Outlet />}
+      </Box>
+      {isMobile && <OverlayToLayout />}
+    </Box>
   );
 };
 

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,24 +1,32 @@
-import { Button, Flex, Heading, Image, Text } from "@chakra-ui/react";
-import { NavLink } from "react-router-dom";
+import { Button, Flex, Heading, Image, Text } from '@chakra-ui/react';
 import Logo from '@/assets/logo.svg';
+import { useEffect } from 'react';
+import useSidenavbarStore from '@/store/useSidenavbarStore';
+import { NavLink } from 'react-router-dom';
 
 const NotFoundPage = () => {
+
+    const { setIsOpen } = useSidenavbarStore();
+    useEffect(() => setIsOpen(false), [])
+
     return (
         <Flex h={"100vh"} direction={"column"} alignItems={"center"} justifyContent={"center"} textAlign="center" gap={4} py={10} px={6}>
             <Image
                 src={Logo}
                 alt="Logo Bee Track"
-                maxW={"150px"}/>
+                maxW={"150px"} />
             <Heading as="h1" size="2xl" mb={4}>
                 404
             </Heading>
             <Text fontSize="lg" mb={6}>
                 Lo sentimos, la página que buscas no existe.
             </Text>
-            <Button asChild>
-                <NavLink to={"/"}>
-                    Volver al inicio
-                </NavLink>
+            <Button
+                asChild
+                colorPalette={"yellow"}
+                bg={{ base: "colorPalette.500", _hover: "colorPalette.400" }}
+                borderRadius={"16px"} >
+                <NavLink to={"/"}>Volver a inicio</NavLink>
             </Button>
         </Flex>
     );

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,14 @@
+import { Box, Heading, Text } from '@chakra-ui/react';
+
+const ProfilePage = () => {
+  return (
+    <Box p={4}>
+      <Heading mb={4}>Profile Page</Heading>
+      <Box bg="white" p={6} borderRadius="lg" boxShadow="sm">
+        <Text mb={4} color={"black"} textAlign={"center"}>Esto es el perfil</Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default ProfilePage;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,11 +1,12 @@
-import { Routes, Route } from 'react-router-dom'
-import PrivateLayout from '@/layout/PrivateLayout'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from '@/pages/Login'
 import Register from '@/pages/Register'
 import DashboardPage from '@/pages/DashboardPage'
 import InventoryPage from '@/pages/InventoryPage'
 import PrivateRoutes from '@/routes/PrivateRoutes'
 import NotFoundPage from '@/pages/NotFoundPage'
+import ProfilePage from '@/pages/ProfilePage'
+import PrivateLayout from '@/layout/PrivateLayout'
 
 const AppRoutes = () => {
   return (
@@ -20,10 +21,12 @@ const AppRoutes = () => {
           <Route index element={<DashboardPage />} />
           <Route path="home" element={<DashboardPage />} />
           <Route path="inventario" element={<InventoryPage />} />
+          <Route path="perfil" element={<ProfilePage />} />
         </Route>
       </Route>
 
-      <Route path="*" element={<NotFoundPage />}></Route>
+      <Route path="/404" element={<NotFoundPage />} />
+      <Route path="*" element={<Navigate to={"/404"} replace />} />
     </Routes>
   )
 }

--- a/src/routes/routesMetadata.ts
+++ b/src/routes/routesMetadata.ts
@@ -1,0 +1,13 @@
+const ROUTES_METADATA: Record<string, { title: string }> = {
+	"/": { title: "Nombre tienda" }, // Cambiar por contenido del authStore
+	"/home": { title: "Dashboard" },
+	"/inventario": { title: "Inventario" },
+	"/ventas": { title: "Ventas" },
+	"/estadisticas": { title: "Estadísticas" },
+	"/perfil": { title: "Perfil" },
+	"/404": { title: "Página no encontrada" },
+	// "/login": { title: "Iniciar sesión" },
+	// "/register": { title: "Registro" },
+}
+
+export default ROUTES_METADATA

--- a/src/store/useSidenavbarStore.ts
+++ b/src/store/useSidenavbarStore.ts
@@ -3,20 +3,33 @@ import { devtools } from 'zustand/middleware';
 
 interface SidenavbarState {
     isOpen: boolean;
-    setIsOpen: (status: boolean) => void;
+    isToggle: boolean;
+    titleToTopBar: string;
+    setIsOpen: (status? : boolean) => void;
+    setToggle: (status? : boolean) => void;
+    setTitleToTopBar: (title : string) => void;
 }
 
 const useSidenavbarStore = create<SidenavbarState>()(
     devtools(
         (set) => ({
             isOpen: false,
+            isToggle: false,
+            titleToTopBar: "Nombre de la tienda",
             setIsOpen: (status) => {
-
-                set({ isOpen: status })
-
-                status
-                    ? document.body.style.overflow = "hidden"
-                    : document.body.style.overflow = "auto";
+                set((state) => ({
+                    isOpen: status ? status : !state.isOpen
+                }))
+            },
+            setToggle: (status) => {
+                set((state) => ({
+                    isToggle: status ? status : !state.isToggle
+                }))
+            },
+            setTitleToTopBar: (title) => {
+                set({
+                    titleToTopBar: title
+                })
             },
         }),
 { name: "SidenavbarStore" }


### PR DESCRIPTION
PR un tanto "compleja".

1. Reestructuro el layout privado para que se comporte bien en relación al planteamiento UX/UI. Tenemos dos partes principales, sidenavbar + contenido. El sidenavbar siempre es fijo en scroll, toggeable en desktop, y se puede ocultar en mobile. El main por su parte tiene un topbar y el contenido principal {children}.

2. Reestructuro también el sidenavbar para que se ajuste al diseño. Me sirvo de un estado de Zustand para comprobar su estado, y ayudar al topbar a renderizar el título correcto en cada vista. También me sirvo de un hook para gestionar el autocerrado en mobile.

3. Introduzco un archivo de metadata para las rutas. Este puede ser interesante para otro tipo de configuraciones. En mi caso lo necesito para la navegación correcta y la renderización correcta del título en el top bar.